### PR TITLE
Fixed alignement issue and date post dates.

### DIFF
--- a/cmd/gobster/display/list/list.go
+++ b/cmd/gobster/display/list/list.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	bubblelist "github.com/charmbracelet/bubbles/list"
@@ -20,6 +21,7 @@ var tagDefaultBackground lipgloss.AdaptiveColor = lipgloss.AdaptiveColor{Light: 
 var tagRedBackground lipgloss.AdaptiveColor = lipgloss.AdaptiveColor{Light: "#3b1719", Dark: "#cf8488"}
 var tagGreyBackground lipgloss.AdaptiveColor = lipgloss.AdaptiveColor{Light: "#c2c2c2", Dark: "#d4d4d4"}
 var tagBlueBackground lipgloss.AdaptiveColor = lipgloss.AdaptiveColor{Light: "#15293d", Dark: "#9fbfde"}
+var dimForeground lipgloss.AdaptiveColor = lipgloss.AdaptiveColor{Light: "#343434", Dark: "#727272"}
 
 var catBackgrounds map[string]lipgloss.AdaptiveColor = map[string]lipgloss.AdaptiveColor{
 	"ask":        tagRedBackground,
@@ -39,13 +41,14 @@ type Item struct {
 	title      string
 	categories []string
 	Url        string
+	date       *time.Time
 }
 
 func (i Item) FilterValue() string { return i.title + strings.Join(i.categories, " ") }
 
 type itemDelegate struct{}
 
-func (d itemDelegate) Height() int                                   { return 1 }
+func (d itemDelegate) Height() int                                   { return 2 }
 func (d itemDelegate) Spacing() int                                  { return 0 }
 func (d itemDelegate) Update(_ tea.Msg, _ *bubblelist.Model) tea.Cmd { return nil }
 
@@ -72,6 +75,7 @@ func NewList(feed *gofeed.Feed, initialTermSize [2]int) bubblelist.Model {
 			title:      v.Title,
 			categories: v.Categories,
 			Url:        v.Link,
+			date:       v.PublishedParsed,
 		})
 	}
 	l.SetItems(items)

--- a/cmd/gobster/display/list/render.go
+++ b/cmd/gobster/display/list/render.go
@@ -4,9 +4,15 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	bubblelist "github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	itemPrefixLength = len("➜  1. ")
+	dateFormat       = "Mon _2 Jan 2006 - 15:04"
 )
 
 func (d itemDelegate) Render(w io.Writer, m bubblelist.Model, index int, listItem bubblelist.Item) {
@@ -22,21 +28,25 @@ func (d itemDelegate) Render(w io.Writer, m bubblelist.Model, index int, listIte
 
 // Renders the item's main line (index, title and categories)
 func (d itemDelegate) renderMainLine(i Item, index int, selected bool) string {
-	style := lipgloss.NewStyle().PaddingLeft(4)
+	padding := 4
 	if selected {
-		style = style.PaddingLeft(2)
+		padding = 2
 	}
+
+	style := lipgloss.NewStyle().PaddingLeft(padding)
+
 	indexStr := d.renderIndex(index, selected)
 	titleStr := d.renderTitle(i.title, selected)
 	categoriesStr := d.renderCategories(i.categories)
-	str := fmt.Sprintf("%s %s %s", indexStr, titleStr, categoriesStr)
+	dateStr := d.renderDate(i.date)
+	str := fmt.Sprintf("%s %s %s\n%[4]*s%s", indexStr, titleStr, categoriesStr, itemPrefixLength-padding, "", dateStr)
 	return style.Render(str)
 }
 
 // Renders the item's index
 func (d itemDelegate) renderIndex(index int, selected bool) string {
 	style := lipgloss.NewStyle()
-	fmtIndex := fmt.Sprintf("%d.", index+1)
+	fmtIndex := fmt.Sprintf("%2d.", index+1)
 	if selected {
 		style = style.Bold(true)
 		return style.Render("➜ " + fmtIndex)
@@ -72,4 +82,14 @@ func (d itemDelegate) renderCategory(cat string) string {
 	}
 	style := lipgloss.NewStyle().Foreground(bgColor).Italic(true)
 	return style.Render("<" + cat + ">")
+}
+
+func (d itemDelegate) renderDate(date *time.Time) string {
+	if date == nil {
+		return ""
+	}
+
+	style := lipgloss.NewStyle().Foreground(dimForeground)
+
+	return style.Render(date.Format(dateFormat))
 }

--- a/cmd/gobster/display/list/render_test.go
+++ b/cmd/gobster/display/list/render_test.go
@@ -2,8 +2,13 @@ package list
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testDate = time.Date(2024, 1, 1, 14, 30, 0, 0, time.UTC)
 )
 
 func TestRenderIndex(t *testing.T) {
@@ -11,7 +16,7 @@ func TestRenderIndex(t *testing.T) {
 
 	str := delegate.renderIndex(3, false)
 
-	assert.Equal(t, "4.", str)
+	assert.Equal(t, " 4.", str)
 }
 
 func TestRenderTitle(t *testing.T) {
@@ -46,11 +51,12 @@ func TestRenderMainLine(t *testing.T) {
 			"programming",
 			"go",
 		},
+		date: &testDate,
 	}
 
 	str := delegate.renderMainLine(item, 1, false)
 	strSelected := delegate.renderMainLine(item, 1, true)
 
-	assert.Equal(t, "    2. Title <programming> <go>", str)
-	assert.Equal(t, "  ➜ 2. Title <programming> <go>", strSelected)
+	assert.Equal(t, "     2. Title <programming> <go>\n        Mon  1 Jan 2024 - 14:30 ", str)
+	assert.Equal(t, "  ➜  2. Title <programming> <go>\n        Mon  1 Jan 2024 - 14:30 ", strSelected)
 }


### PR DESCRIPTION
This merge request does two things. The first, optional change adds the post date. The second is more critical and fixes an alignment issue when a post ID goes from 1 digit to 2 digits. I consider this as breaking immersion, literally unplayable. /s

Before:

```
    9. Tagged Union Subsets with Comptime in Zig <zig>                                                                          
    10. Refactoring Python with Tree-sitter & Jedi <python>
```

After:

```
     9. Tagged Union Subsets with Comptime in Zig <zig>                                                    
    10. Refactoring Python with Tree-sitter & Jedi <python>
```